### PR TITLE
Map dependencies' names (version 1)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,11 +51,13 @@ Use dependency
 
 To use dependency you need to add it's name to ``__dependencies__`` property
 for every service which depends on it. Specified dependencies will be injected
-as service's attributes on entrypoint startup.
+as service's attributes on entrypoint startup. If needed to map the dependency
+with a different name, then, use ``__dependencies_map__``
 
 .. code-block:: python
 
     from contextlib import suppress
+    from types import MappingProxyType
 
     import aiohttp
     from aiomisc.service.aiohttp import AIOHTTPService
@@ -85,6 +87,12 @@ as service's attributes on entrypoint startup.
     class RESTService(AIOHTTPService):
 
         __dependencies__ = ('pg_engine',)
+
+        ...
+
+    class AnotherRESTService(AIOHTTPService):
+
+        __dependencies_map__ = MappingProxyType({'pg_engine': 'engine'})
 
         ...
 

--- a/aiomisc_dependency/__init__.py
+++ b/aiomisc_dependency/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from collections import namedtuple
 from functools import wraps
-from typing import Mapping
+from typing import Mapping, Sequence, AbstractSet
 
 from aiodine.store import Store
 
@@ -35,12 +35,12 @@ async def inject(target, *, dependencies_list, dependencies_map):
     dependencies_list = dependencies_list or []
     dependencies_map = dependencies_map or {}
     if (
-        isinstance(dependencies_list, Mapping) or
+        not isinstance(dependencies_list, (AbstractSet, Sequence)) or
         not isinstance(dependencies_map, Mapping)
     ):
         raise ValueError(
-            '__dependencies__ must be not be mapping, '
-            'whereas __dependencies_map__ must be'
+            '__dependencies__ must be a sequence or a set, '
+            'whereas __dependencies_map__ must be a mapping'
         )
 
     dependencies = _aggregate(

--- a/aiomisc_dependency/__init__.py
+++ b/aiomisc_dependency/__init__.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from functools import wraps
+from typing import Mapping
 
 from aiodine.store import Store
 
@@ -13,9 +14,20 @@ def dependency(func):
     return STORE.provider(scope='session')(func)
 
 
-async def inject(target, dependencies):
+def _construct_mapping(dependencies) -> dict:
+    if isinstance(dependencies, Mapping):
+        return dict(dependencies)
 
-    deps_holder = namedtuple('DepsHolder', dependencies)
+    return dict([
+        (dep, dep) if isinstance(dep, str) else dep
+        for dep in dependencies
+    ])
+
+
+async def inject(target, dependencies):
+    dependencies = _construct_mapping(dependencies)
+
+    deps_holder = namedtuple('DepsHolder', list(dependencies.keys()))
 
     @wraps(deps_holder)
     async def async_deps_holder(*args):
@@ -27,15 +39,18 @@ async def inject(target, dependencies):
 
     for name in dependencies:
         value = getattr(resolved_deps, name)
+        target_name = dependencies[name]
 
         # Check that has default class value non-overriden by init.
         default = (
-             hasattr(target, name) and
-             hasattr(target.__class__, name) and
-             getattr(target, name) == getattr(target.__class__, name)
+             hasattr(target, target_name) and
+             hasattr(target.__class__, target_name) and
+             getattr(target, target_name) == getattr(
+                target.__class__, target_name
+             )
         )
 
-        if not hasattr(target, name) or default:
+        if not hasattr(target, target_name) or default:
             if value is NOT_FOUND_DEP:
                 # If default class value => no injection
                 if not default:
@@ -45,7 +60,7 @@ async def inject(target, dependencies):
                 else:
                     continue
 
-            setattr(target, name, value)
+            setattr(target, target_name, value)
 
 
 async def enter_session():

--- a/aiomisc_dependency/plugin.py
+++ b/aiomisc_dependency/plugin.py
@@ -10,8 +10,14 @@ async def resolve_dependencies(entrypoint, services):
     freeze()
     await enter_session()
     for svc in services:
-        if hasattr(svc, '__dependencies__'):
-            await inject(svc, svc.__dependencies__)
+        dependencies_list = getattr(svc, '__dependencies__', None)
+        dependencies_map = getattr(svc, '__dependencies_map__', None)
+        if dependencies_list or dependencies_map:
+            await inject(
+                svc,
+                dependencies_list=dependencies_list,
+                dependencies_map=dependencies_map,
+            )
 
 
 async def clear_dependencies(entrypoint):

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -310,7 +310,10 @@ def test_dependency_injection_reuse():
 @pytest.mark.parametrize(
     'dependencies,dependencies_map', [
         (['baz'], {'foo': 'bar'}),
+        (['baz', 'foo'], {'foo': 'bar'}),
+        ([], {'foo': 'bar', 'baz': 'baz'}),
         (None, {'foo': 'bar', 'baz': 'baz'}),
+        (None, MappingProxyType({'foo': 'bar', 'baz': 'baz'})),
     ]
 )
 def test_dependency_inject_mapping(dependencies, dependencies_map):

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -28,7 +28,10 @@ async def test_register_dependency():
 
 @pytest.mark.parametrize(
     'dependencies_list,dependencies_map', [
+        (['foo', 'bar'], None),
         (('foo', 'bar'), None),
+        ({'foo', 'bar'}, None),
+        (frozenset(['foo', 'bar']), None),
         (('foo',), {'bar': 'bar'}),
         (None, {'foo': 'foo', 'bar': 'bar'}),
         (None, MappingProxyType({'foo': 'foo', 'bar': 'bar'})),


### PR DESCRIPTION
It would be nice to be able to inject the same dependency with different names to different services. For example
- You have parent service `ParentService` with parameter `bar`
- Inherit with `ChildService`
- Inject some existing dependency `foo` as `bar`