### PR TITLE
Fix clear_dependencies args

### DIFF
--- a/aiomisc_dependency/plugin.py
+++ b/aiomisc_dependency/plugin.py
@@ -1,7 +1,7 @@
 from . import freeze, enter_session, exit_session, inject, dependency
 
 
-async def resolve_dependencies(entrypoint, services):
+async def resolve_dependencies(entrypoint, services, **_):
 
     @dependency
     def loop():
@@ -20,7 +20,7 @@ async def resolve_dependencies(entrypoint, services):
             )
 
 
-async def clear_dependencies(entrypoint, services=None):
+async def clear_dependencies(entrypoint, **_):
     await exit_session()
 
 

--- a/aiomisc_dependency/plugin.py
+++ b/aiomisc_dependency/plugin.py
@@ -20,7 +20,7 @@ async def resolve_dependencies(entrypoint, services):
             )
 
 
-async def clear_dependencies(entrypoint):
+async def clear_dependencies(entrypoint, services=None):
     await exit_session()
 
 


### PR DESCRIPTION
In `aiomisc.Entrypoint` the `services` argument was added to the `POST_STOP` signal, hence, `clear_dependencies` began to fail.
https://github.com/aiokitchen/aiomisc/blob/master/aiomisc/entrypoint.py#L375